### PR TITLE
First pass of dockerizing the pydip server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ venv
 .idea/
 *.pyc
 .cache/
+docker-build
+docker-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+MAINTAINER Aric Parkinson <aric.parkinson@gmail.com>
+
+RUN apt-get update && \
+    apt-get install -y \
+        libpq-dev \
+        python3 \
+        python3-pip
+
+COPY dip_server/ /opt/verbose_carnival/dip_server/
+WORKDIR /opt/verbose_carnival/dip_server/
+RUN pip3 install -r requirements.txt

--- a/dip_server/dip_server/settings.py
+++ b/dip_server/dip_server/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = '!er(@xo&pvd^8$&s868zbiqv5p+aba!52t_p%!_5^chq-fr11='
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/dip_server/manage.py
+++ b/dip_server/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/dip_server/requirements.txt
+++ b/dip_server/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.10.4
-psycopg2==2.6.2
+psycopg2==2.7.5
 py==1.4.32
 pydip==0.1.8
 pytest==3.0.6

--- a/docker-build.example
+++ b/docker-build.example
@@ -1,0 +1,1 @@
+docker build -t pydip .

--- a/docker-run.example
+++ b/docker-run.example
@@ -1,0 +1,9 @@
+docker run \
+    -e PGDATABASE="TODO" \
+    -e PGUSER="TODO" \
+    -e PGPASSWORD="TODO" \
+    -e PGHOST="TODO" \
+    -e PGPORT="TODO" \
+-it -p 8000:8000 \
+pydip:latest \
+bash


### PR DESCRIPTION
 - This commit introduces a basic Dockerfile for building an image to
 run the dip_server, as well as example docker-build and docker-run
 scripts for executing the docker image locally. Note: you should
 definitely fill in the PG* variables with configurations for a personal
 PostgreSQL server to have these actually work.
 - At present I seem to be having difficulty actually connecting, but I
 can't tell if that's quirkiness with Docker for Mac, or something about
 Django in the container. I'm going to push this to a remote branch and
 check in an Ubuntu VM to confirm.
 - ALLOWED_HOSTS = ['*'] is there to allow arbitrary AWS domain names to
 function properly. Long term we might want to lock that down, but while
 we're just trying to get a working prototype going, I'm definitely fine
 having everything open.